### PR TITLE
Add HTTP timeout settings with per-call overrides

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ kubex/                          # Main package
     ├── request.py              # Request dataclass
     ├── response.py             # Response dataclass + HeadersWrapper
     ├── params.py               # API option classes (ListOptions, GetOptions, DeleteOptions, etc.)
+                                #   + Timeout, TimeoutTypes — HTTP timeout configuration
     ├── patch.py                # Patch protocols (ApplyPatch, MergePatch, StrategicMergePatch, JsonPatch)
     ├── subresource.py          # Subresource definitions
     └── request_builder/        # Constructs HTTP requests from API calls
@@ -110,9 +111,10 @@ test/                           # Test suite
 │   ├── conftest.py             # Fixtures: K3S container, client fixtures, temp namespace
 │   ├── test_core_api_pod.py    # Pod CRUD tests
 │   └── test_core_api_namespaces.py  # Namespace listing tests
-└── test_configuration/         # Unit tests
-    └── auth/
-        └── test_exec_provider.py # Exec provider unit tests
+├── test_configuration/         # Unit tests
+│   └── auth/
+│       └── test_exec_provider.py # Exec provider unit tests
+└── test_timeout/               # Unit tests for HTTP timeout settings
 
 examples/                       # Usage examples
 ├── get_pod.py                  # Create, get, list metadata, delete a Pod
@@ -172,8 +174,10 @@ All models inherit from `BaseK8sModel` which uses `alias_generator=to_camel` and
 ### Configuration auto-loading
 `create_client()` → tries kubeconfig file first → falls back to in-cluster pod environment.
 
-### Namespace handling with Ellipsis sentinel
-`Ellipsis` (`...`) is used as a sentinel to distinguish "not provided" (use the default) from `None` (explicitly no namespace). This allows setting a default namespace on the `Api` instance while still overriding per-call.
+### Ellipsis sentinel for optional overrides
+`Ellipsis` (`...`) is used as a sentinel to distinguish "not provided" (use the default) from `None` (explicitly disabled). This pattern is used in two places:
+- **Namespace**: `...` = use the `Api` instance default; `None` = explicitly no namespace.
+- **Request timeout**: `...` = use the client-level default (or the HTTP library default if none was configured); `None` = explicitly disable timeouts for this call.
 
 ### Exception hierarchy
 ```
@@ -198,7 +202,7 @@ Resources declare capabilities via multiple inheritance from marker classes: `Na
 
 - **Framework**: pytest with `pytest-cov` and `anyio` for async support
 - **E2E tests** use `testcontainers` with a K3S container (requires Docker); located in `test/e2e/`
-- **Unit tests** for configuration/auth in `test/test_configuration/`
+- **Unit tests** for configuration/auth in `test/test_configuration/`, timeout settings in `test/test_timeout/`
 - **Codegen tests** with golden snapshots in `scripts/codegen/tests/`
 - E2E tests are parameterized over both HTTP clients (`httpx`, `aiohttp`) and async backends (`asyncio`, `trio` — trio only with httpx)
 - Mark async tests with `@pytest.mark.anyio`

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Kubex works with both **asyncio** and **trio** (via httpx), with no framework lo
 # Planned Features:
 
 * [ ] Support for OIDC and other authentication extensions.
-* [ ] Fine-tuning of timeouts.
+* [x] Fine-tuning of timeouts.
 * [ ] Dynamic API object creation to exclude unsupported methods for resources (requires research for mypy compatibility).
 * [ ] Potential synchronous version of the client.
 * [ ] Additional tests and examples.

--- a/kubex/api/_logs.py
+++ b/kubex/api/_logs.py
@@ -8,7 +8,6 @@ from ._protocol import (
     ApiNamespaceTypes,
     ApiProtocol,
     ApiRequestTimeoutTypes,
-    apply_request_timeout,
 )
 
 
@@ -57,9 +56,8 @@ class LogsMixin(ApiProtocol[ResourceType]):
             tail_lines=tail_lines,
             timestamps=timestamps,
         )
-        request = apply_request_timeout(
-            self._request_builder.logs(name, _namespace, options=options),
-            request_timeout,
+        request = self._request_builder.logs(
+            name, _namespace, options=options, request_timeout=request_timeout
         )
         response = await self._client.request(request)
         return response.text
@@ -111,9 +109,8 @@ class LogsMixin(ApiProtocol[ResourceType]):
             tail_lines=tail_lines,
             timestamps=timestamps,
         )
-        request = apply_request_timeout(
-            self._request_builder.stream_logs(name, _namespace, options=options),
-            request_timeout,
+        request = self._request_builder.stream_logs(
+            name, _namespace, options=options, request_timeout=request_timeout
         )
         async for line in self._client.stream_lines(request):
             yield line

--- a/kubex/api/_logs.py
+++ b/kubex/api/_logs.py
@@ -4,7 +4,12 @@ from kubex.core.params import LogOptions
 from kubex_core.models.interfaces import HasLogs
 from kubex_core.models.typing import ResourceType
 
-from ._protocol import ApiNamespaceTypes, ApiProtocol
+from ._protocol import (
+    ApiNamespaceTypes,
+    ApiProtocol,
+    ApiRequestTimeoutTypes,
+    apply_request_timeout,
+)
 
 
 class LogsMixin(ApiProtocol[ResourceType]):
@@ -39,6 +44,7 @@ class LogsMixin(ApiProtocol[ResourceType]):
         since_seconds: int | None = None,
         tail_lines: int | None = None,
         timestamps: bool | None = None,
+        request_timeout: ApiRequestTimeoutTypes = Ellipsis,
     ) -> str:
         self._check_implemented()
         _namespace = self._ensure_required_namespace(namespace)
@@ -51,7 +57,10 @@ class LogsMixin(ApiProtocol[ResourceType]):
             tail_lines=tail_lines,
             timestamps=timestamps,
         )
-        request = self._request_builder.logs(name, _namespace, options=options)
+        request = apply_request_timeout(
+            self._request_builder.logs(name, _namespace, options=options),
+            request_timeout,
+        )
         response = await self._client.request(request)
         return response.text
 
@@ -82,7 +91,15 @@ class LogsMixin(ApiProtocol[ResourceType]):
         since_seconds: int | None = None,
         tail_lines: int | None = None,
         timestamps: bool | None = None,
+        request_timeout: ApiRequestTimeoutTypes = Ellipsis,
     ) -> AsyncGenerator[str, None]:
+        """Stream container logs.
+
+        Args:
+            request_timeout: HTTP-level timeout override for this call. A short
+                read/total timeout will terminate the long-lived log stream;
+                disable the read timeout or leave this unset.
+        """
         self._check_implemented()
         _namespace = self._ensure_required_namespace(namespace)
         options = LogOptions(
@@ -94,7 +111,9 @@ class LogsMixin(ApiProtocol[ResourceType]):
             tail_lines=tail_lines,
             timestamps=timestamps,
         )
-        request = self._request_builder.stream_logs(name, _namespace, options=options)
-        # TODO: ReadTimeout
+        request = apply_request_timeout(
+            self._request_builder.stream_logs(name, _namespace, options=options),
+            request_timeout,
+        )
         async for line in self._client.stream_lines(request):
             yield line

--- a/kubex/api/_metadata.py
+++ b/kubex/api/_metadata.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import json
 from typing import AsyncGenerator
 
-from kubex.api._protocol import ApiNamespaceTypes, ApiProtocol
+from kubex.api._protocol import (
+    ApiNamespaceTypes,
+    ApiProtocol,
+    ApiRequestTimeoutTypes,
+    apply_request_timeout,
+)
 from kubex.core.params import (
     DryRunTypes,
     FieldValidation,
@@ -30,10 +35,14 @@ class MetadataMixin(ApiProtocol[ResourceType]):
         *,
         namespace: ApiNamespaceTypes = Ellipsis,
         resource_version: ResourceVersionTypes = None,
+        request_timeout: ApiRequestTimeoutTypes = Ellipsis,
     ) -> PartialObjectMetadata:
         _namespace = self._ensure_required_namespace(namespace)
         options = GetOptions(resource_version=resource_version)
-        request = self._request_builder.get_metadata(name, _namespace, options=options)
+        request = apply_request_timeout(
+            self._request_builder.get_metadata(name, _namespace, options=options),
+            request_timeout,
+        )
         response = await self._client.request(request)
         return PartialObjectMetadata.model_validate_json(response.content)
 
@@ -48,6 +57,7 @@ class MetadataMixin(ApiProtocol[ResourceType]):
         continue_token: str | None = None,
         version_match: VersionMatch | None = None,
         resource_version: ResourceVersionTypes = None,
+        request_timeout: ApiRequestTimeoutTypes = Ellipsis,
     ) -> ListEntity[PartialObjectMetadata]:
         _namespace = self._ensure_optional_namespace(namespace)
         options = ListOptions(
@@ -59,7 +69,9 @@ class MetadataMixin(ApiProtocol[ResourceType]):
             version_match=version_match,
             resource_version=resource_version,
         )
-        request = self._request_builder.list_metadata(_namespace, options)
+        request = apply_request_timeout(
+            self._request_builder.list_metadata(_namespace, options), request_timeout
+        )
         response = await self._client.request(request)
         model = PartialObjectMetadata.__RESOURCE_CONFIG__.list_model
         return model.model_validate_json(response.content)
@@ -74,6 +86,7 @@ class MetadataMixin(ApiProtocol[ResourceType]):
         field_manager: str | None = None,
         force: bool | None = None,
         field_validation: FieldValidation | None = None,
+        request_timeout: ApiRequestTimeoutTypes = Ellipsis,
     ) -> PartialObjectMetadata:
         _namespace = self._ensure_required_namespace(namespace)
         options = PatchOptions(
@@ -82,7 +95,10 @@ class MetadataMixin(ApiProtocol[ResourceType]):
             force=force,
             field_validation=field_validation,
         )
-        request = self._request_builder.patch_metadata(name, _namespace, options, patch)
+        request = apply_request_timeout(
+            self._request_builder.patch_metadata(name, _namespace, options, patch),
+            request_timeout,
+        )
         response = await self._client.request(request)
         return PartialObjectMetadata.model_validate_json(response.content)
 
@@ -96,6 +112,7 @@ class MetadataMixin(ApiProtocol[ResourceType]):
         send_initial_events: bool | None = None,
         timeout_seconds: int | None = None,
         resource_version: ResourceVersionTypes = None,
+        request_timeout: ApiRequestTimeoutTypes = Ellipsis,
     ) -> AsyncGenerator[
         WatchEvent[PartialObjectMetadata],
         None,
@@ -108,8 +125,11 @@ class MetadataMixin(ApiProtocol[ResourceType]):
             send_initial_events=send_initial_events,
             timeout_seconds=timeout_seconds,
         )
-        request = self._request_builder.watch_metadata(
-            _namespace, options, resource_version=resource_version
+        request = apply_request_timeout(
+            self._request_builder.watch_metadata(
+                _namespace, options, resource_version=resource_version
+            ),
+            request_timeout,
         )
         async for line in self._client.stream_lines(request):
             yield WatchEvent(PartialObjectMetadata, json.loads(line))

--- a/kubex/api/_metadata.py
+++ b/kubex/api/_metadata.py
@@ -7,7 +7,6 @@ from kubex.api._protocol import (
     ApiNamespaceTypes,
     ApiProtocol,
     ApiRequestTimeoutTypes,
-    apply_request_timeout,
 )
 from kubex.core.params import (
     DryRunTypes,
@@ -39,9 +38,8 @@ class MetadataMixin(ApiProtocol[ResourceType]):
     ) -> PartialObjectMetadata:
         _namespace = self._ensure_required_namespace(namespace)
         options = GetOptions(resource_version=resource_version)
-        request = apply_request_timeout(
-            self._request_builder.get_metadata(name, _namespace, options=options),
-            request_timeout,
+        request = self._request_builder.get_metadata(
+            name, _namespace, options=options, request_timeout=request_timeout
         )
         response = await self._client.request(request)
         return PartialObjectMetadata.model_validate_json(response.content)
@@ -69,8 +67,8 @@ class MetadataMixin(ApiProtocol[ResourceType]):
             version_match=version_match,
             resource_version=resource_version,
         )
-        request = apply_request_timeout(
-            self._request_builder.list_metadata(_namespace, options), request_timeout
+        request = self._request_builder.list_metadata(
+            _namespace, options, request_timeout=request_timeout
         )
         response = await self._client.request(request)
         model = PartialObjectMetadata.__RESOURCE_CONFIG__.list_model
@@ -95,9 +93,8 @@ class MetadataMixin(ApiProtocol[ResourceType]):
             force=force,
             field_validation=field_validation,
         )
-        request = apply_request_timeout(
-            self._request_builder.patch_metadata(name, _namespace, options, patch),
-            request_timeout,
+        request = self._request_builder.patch_metadata(
+            name, _namespace, options, patch, request_timeout=request_timeout
         )
         response = await self._client.request(request)
         return PartialObjectMetadata.model_validate_json(response.content)
@@ -125,11 +122,11 @@ class MetadataMixin(ApiProtocol[ResourceType]):
             send_initial_events=send_initial_events,
             timeout_seconds=timeout_seconds,
         )
-        request = apply_request_timeout(
-            self._request_builder.watch_metadata(
-                _namespace, options, resource_version=resource_version
-            ),
-            request_timeout,
+        request = self._request_builder.watch_metadata(
+            _namespace,
+            options,
+            resource_version=resource_version,
+            request_timeout=request_timeout,
         )
         async for line in self._client.stream_lines(request):
             yield WatchEvent(PartialObjectMetadata, json.loads(line))

--- a/kubex/api/_protocol.py
+++ b/kubex/api/_protocol.py
@@ -2,11 +2,26 @@ from types import EllipsisType
 from typing import Protocol, Type
 
 from kubex.client.client import BaseClient
-from kubex.core.params import NamespaceTypes
+from kubex.core.params import NamespaceTypes, Timeout, TimeoutTypes
+from kubex.core.request import Request
 from kubex.core.request_builder.builder import RequestBuilder
 from kubex_core.models.typing import ResourceType
 
 ApiNamespaceTypes = NamespaceTypes | EllipsisType
+ApiRequestTimeoutTypes = TimeoutTypes | EllipsisType
+
+
+def apply_request_timeout(request: Request, value: ApiRequestTimeoutTypes) -> Request:
+    """Apply a per-call ``request_timeout`` to a ``Request``.
+
+    ``Ellipsis`` (the default) leaves the request untouched so the client's
+    configured default applies. ``None`` explicitly disables the timeout.
+    Any other value is normalized via :func:`Timeout.coerce`.
+    """
+    if value is Ellipsis:
+        return request
+    request.timeout = Timeout.coerce(value)
+    return request
 
 
 class ApiProtocol(Protocol[ResourceType]):

--- a/kubex/api/_protocol.py
+++ b/kubex/api/_protocol.py
@@ -2,26 +2,12 @@ from types import EllipsisType
 from typing import Protocol, Type
 
 from kubex.client.client import BaseClient
-from kubex.core.params import NamespaceTypes, Timeout, TimeoutTypes
-from kubex.core.request import Request
+from kubex.core.params import NamespaceTypes, TimeoutTypes
 from kubex.core.request_builder.builder import RequestBuilder
 from kubex_core.models.typing import ResourceType
 
 ApiNamespaceTypes = NamespaceTypes | EllipsisType
 ApiRequestTimeoutTypes = TimeoutTypes | EllipsisType
-
-
-def apply_request_timeout(request: Request, value: ApiRequestTimeoutTypes) -> Request:
-    """Apply a per-call ``request_timeout`` to a ``Request``.
-
-    ``Ellipsis`` (the default) leaves the request untouched so the client's
-    configured default applies. ``None`` explicitly disables the timeout.
-    Any other value is normalized via :func:`Timeout.coerce`.
-    """
-    if value is Ellipsis:
-        return request
-    request.timeout = Timeout.coerce(value)
-    return request
 
 
 class ApiProtocol(Protocol[ResourceType]):

--- a/kubex/api/_subressource.py
+++ b/kubex/api/_subressource.py
@@ -15,7 +15,6 @@ from ._protocol import (
     ApiNamespaceTypes,
     ApiProtocol,
     ApiRequestTimeoutTypes,
-    apply_request_timeout,
 )
 
 SCALE_SUBRESOURCE = "scale"
@@ -37,9 +36,8 @@ class ScaleMixin(ApiProtocol[ResourceType]):
     ) -> Scale:
         self._check_implemented()
         _namespace = self._ensure_required_namespace(namespace)
-        request = apply_request_timeout(
-            self._request_builder.get_subresource(SCALE_SUBRESOURCE, name, _namespace),
-            request_timeout,
+        request = self._request_builder.get_subresource(
+            SCALE_SUBRESOURCE, name, _namespace, request_timeout=request_timeout
         )
         response = await self._client.request(request)
         return Scale.model_validate_json(response.content)
@@ -57,17 +55,15 @@ class ScaleMixin(ApiProtocol[ResourceType]):
         self._check_implemented()
         _namespace = self._ensure_required_namespace(namespace)
         options = PostOptions(dry_run=dry_run, field_manager=field_manager)
-        request = apply_request_timeout(
-            self._request_builder.replace_subresource(
-                SCALE_SUBRESOURCE,
-                name,
-                _namespace,
-                data=scale.model_dump_json(
-                    by_alias=True, exclude_unset=True, exclude_none=True
-                ),
-                options=options,
+        request = self._request_builder.replace_subresource(
+            SCALE_SUBRESOURCE,
+            name,
+            _namespace,
+            data=scale.model_dump_json(
+                by_alias=True, exclude_unset=True, exclude_none=True
             ),
-            request_timeout,
+            options=options,
+            request_timeout=request_timeout,
         )
         response = await self._client.request(request)
         return Scale.model_validate_json(response.content)
@@ -92,15 +88,13 @@ class ScaleMixin(ApiProtocol[ResourceType]):
             force=force,
             field_validation=field_validation,
         )
-        request = apply_request_timeout(
-            self._request_builder.patch_subresource(
-                SCALE_SUBRESOURCE,
-                name,
-                _namespace,
-                options=options,
-                patch=patch,
-            ),
-            request_timeout,
+        request = self._request_builder.patch_subresource(
+            SCALE_SUBRESOURCE,
+            name,
+            _namespace,
+            options=options,
+            patch=patch,
+            request_timeout=request_timeout,
         )
         response = await self._client.request(request)
         return Scale.model_validate_json(response.content)

--- a/kubex/api/_subressource.py
+++ b/kubex/api/_subressource.py
@@ -11,7 +11,12 @@ from kubex_core.models.interfaces import HasScaleSubresource
 from kubex_core.models.scale import Scale
 from kubex_core.models.typing import ResourceType
 
-from ._protocol import ApiNamespaceTypes, ApiProtocol
+from ._protocol import (
+    ApiNamespaceTypes,
+    ApiProtocol,
+    ApiRequestTimeoutTypes,
+    apply_request_timeout,
+)
 
 SCALE_SUBRESOURCE = "scale"
 
@@ -24,12 +29,17 @@ class ScaleMixin(ApiProtocol[ResourceType]):
             )
 
     async def get_scale(
-        self, name: str, *, namespace: ApiNamespaceTypes = Ellipsis
+        self,
+        name: str,
+        *,
+        namespace: ApiNamespaceTypes = Ellipsis,
+        request_timeout: ApiRequestTimeoutTypes = Ellipsis,
     ) -> Scale:
         self._check_implemented()
         _namespace = self._ensure_required_namespace(namespace)
-        request = self._request_builder.get_subresource(
-            SCALE_SUBRESOURCE, name, _namespace
+        request = apply_request_timeout(
+            self._request_builder.get_subresource(SCALE_SUBRESOURCE, name, _namespace),
+            request_timeout,
         )
         response = await self._client.request(request)
         return Scale.model_validate_json(response.content)
@@ -42,18 +52,22 @@ class ScaleMixin(ApiProtocol[ResourceType]):
         namespace: ApiNamespaceTypes = Ellipsis,
         dry_run: DryRunTypes = None,
         field_manager: str | None = None,
+        request_timeout: ApiRequestTimeoutTypes = Ellipsis,
     ) -> Scale:
         self._check_implemented()
         _namespace = self._ensure_required_namespace(namespace)
         options = PostOptions(dry_run=dry_run, field_manager=field_manager)
-        request = self._request_builder.replace_subresource(
-            SCALE_SUBRESOURCE,
-            name,
-            _namespace,
-            data=scale.model_dump_json(
-                by_alias=True, exclude_unset=True, exclude_none=True
+        request = apply_request_timeout(
+            self._request_builder.replace_subresource(
+                SCALE_SUBRESOURCE,
+                name,
+                _namespace,
+                data=scale.model_dump_json(
+                    by_alias=True, exclude_unset=True, exclude_none=True
+                ),
+                options=options,
             ),
-            options=options,
+            request_timeout,
         )
         response = await self._client.request(request)
         return Scale.model_validate_json(response.content)
@@ -68,6 +82,7 @@ class ScaleMixin(ApiProtocol[ResourceType]):
         field_manager: str | None = None,
         force: bool | None = None,
         field_validation: FieldValidation | None = None,
+        request_timeout: ApiRequestTimeoutTypes = Ellipsis,
     ) -> Scale:
         self._check_implemented()
         _namespace = self._ensure_required_namespace(namespace)
@@ -77,12 +92,15 @@ class ScaleMixin(ApiProtocol[ResourceType]):
             force=force,
             field_validation=field_validation,
         )
-        request = self._request_builder.patch_subresource(
-            SCALE_SUBRESOURCE,
-            name,
-            _namespace,
-            options=options,
-            patch=patch,
+        request = apply_request_timeout(
+            self._request_builder.patch_subresource(
+                SCALE_SUBRESOURCE,
+                name,
+                _namespace,
+                options=options,
+                patch=patch,
+            ),
+            request_timeout,
         )
         response = await self._client.request(request)
         return Scale.model_validate_json(response.content)

--- a/kubex/api/api.py
+++ b/kubex/api/api.py
@@ -37,7 +37,7 @@ from kubex_core.models.watch_event import WatchEvent
 
 from ._logs import LogsMixin
 from ._metadata import MetadataMixin
-from ._protocol import ApiNamespaceTypes, ApiRequestTimeoutTypes, apply_request_timeout
+from ._protocol import ApiNamespaceTypes, ApiRequestTimeoutTypes
 
 
 class Api(Generic[ResourceType], MetadataMixin[ResourceType], LogsMixin[ResourceType]):
@@ -123,8 +123,8 @@ class Api(Generic[ResourceType], MetadataMixin[ResourceType], LogsMixin[Resource
         """
         _namespace = self._ensure_required_namespace(namespace)
         options = GetOptions(resource_version=resource_version)
-        request = apply_request_timeout(
-            self._request_builder.get(name, _namespace, options), request_timeout
+        request = self._request_builder.get(
+            name, _namespace, options, request_timeout=request_timeout
         )
         response = await self._client.request(request)
         return self._resource.model_validate_json(response.content)
@@ -177,8 +177,8 @@ class Api(Generic[ResourceType], MetadataMixin[ResourceType], LogsMixin[Resource
             version_match=version_match,
             resource_version=resource_version,
         )
-        request = apply_request_timeout(
-            self._request_builder.list(_namespace, options), request_timeout
+        request = self._request_builder.list(
+            _namespace, options, request_timeout=request_timeout
         )
         response = await self._client.request(request)
         list_model = self._resource.__RESOURCE_CONFIG__.list_model
@@ -211,15 +211,11 @@ class Api(Generic[ResourceType], MetadataMixin[ResourceType], LogsMixin[Resource
         """
         _namespace = self._ensure_required_namespace(namespace)
         options = PostOptions(dry_run=dry_run, field_manager=field_manager)
-        request = apply_request_timeout(
-            self._request_builder.create(
-                _namespace,
-                options,
-                data.model_dump_json(
-                    by_alias=True, exclude_unset=True, exclude_none=True
-                ),
-            ),
-            request_timeout,
+        request = self._request_builder.create(
+            _namespace,
+            options,
+            data.model_dump_json(by_alias=True, exclude_unset=True, exclude_none=True),
+            request_timeout=request_timeout,
         )
         response = await self._client.request(request)
         return self._resource.model_validate_json(response.content)
@@ -264,8 +260,8 @@ class Api(Generic[ResourceType], MetadataMixin[ResourceType], LogsMixin[Resource
             propagation_policy=propagation_policy,
             preconditions=preconditions,
         )
-        request = apply_request_timeout(
-            self._request_builder.delete(name, _namespace, options), request_timeout
+        request = self._request_builder.delete(
+            name, _namespace, options, request_timeout=request_timeout
         )
         response = await self._client.request(request)
         try:
@@ -313,11 +309,11 @@ class Api(Generic[ResourceType], MetadataMixin[ResourceType], LogsMixin[Resource
             propagation_policy=propagation_policy,
             preconditions=preconditions,
         )
-        request = apply_request_timeout(
-            self._request_builder.delete_collection(
-                _namespace, list_options, delete_options
-            ),
-            request_timeout,
+        request = self._request_builder.delete_collection(
+            _namespace,
+            list_options,
+            delete_options,
+            request_timeout=request_timeout,
         )
         response = await self._client.request(request)
         list_model = self._resource.__RESOURCE_CONFIG__.list_model
@@ -352,9 +348,8 @@ class Api(Generic[ResourceType], MetadataMixin[ResourceType], LogsMixin[Resource
             force=force,
             field_validation=field_validation,
         )
-        request = apply_request_timeout(
-            self._request_builder.patch(name, _namespace, options, patch),
-            request_timeout,
+        request = self._request_builder.patch(
+            name, _namespace, options, patch, request_timeout=request_timeout
         )
         response = await self._client.request(request)
         return self._resource.model_validate_json(response.content)
@@ -378,16 +373,12 @@ class Api(Generic[ResourceType], MetadataMixin[ResourceType], LogsMixin[Resource
         """
         _namespace = self._ensure_required_namespace(namespace)
         options = PostOptions(dry_run=dry_run, field_manager=field_manager)
-        request = apply_request_timeout(
-            self._request_builder.replace(
-                name,
-                _namespace,
-                options,
-                data.model_dump_json(
-                    by_alias=True, exclude_unset=True, exclude_none=True
-                ),
-            ),
-            request_timeout,
+        request = self._request_builder.replace(
+            name,
+            _namespace,
+            options,
+            data.model_dump_json(by_alias=True, exclude_unset=True, exclude_none=True),
+            request_timeout=request_timeout,
         )
         response = await self._client.request(request)
         return self._resource.model_validate_json(response.content)
@@ -421,11 +412,11 @@ class Api(Generic[ResourceType], MetadataMixin[ResourceType], LogsMixin[Resource
             send_initial_events=send_initial_events,
             timeout_seconds=timeout_seconds,
         )
-        request = apply_request_timeout(
-            self._request_builder.watch(
-                _namespace, options, resource_version=resource_version
-            ),
-            request_timeout,
+        request = self._request_builder.watch(
+            _namespace,
+            options,
+            resource_version=resource_version,
+            request_timeout=request_timeout,
         )
         async for line in self._client.stream_lines(request):
             yield WatchEvent(self._resource, json.loads(line))

--- a/kubex/api/api.py
+++ b/kubex/api/api.py
@@ -37,7 +37,7 @@ from kubex_core.models.watch_event import WatchEvent
 
 from ._logs import LogsMixin
 from ._metadata import MetadataMixin
-from ._protocol import ApiNamespaceTypes
+from ._protocol import ApiNamespaceTypes, ApiRequestTimeoutTypes, apply_request_timeout
 
 
 class Api(Generic[ResourceType], MetadataMixin[ResourceType], LogsMixin[ResourceType]):
@@ -102,6 +102,7 @@ class Api(Generic[ResourceType], MetadataMixin[ResourceType], LogsMixin[Resource
         *,
         namespace: ApiNamespaceTypes = Ellipsis,
         resource_version: ResourceVersionTypes = None,
+        request_timeout: ApiRequestTimeoutTypes = Ellipsis,
     ) -> ResourceType:
         """Read the specified resource.
 
@@ -114,12 +115,17 @@ class Api(Generic[ResourceType], MetadataMixin[ResourceType], LogsMixin[Resource
             resource_version: The resource version to read. If not provided,
                 the current resource version will be read. For details look at
                 [Resource Version Semantics documentation](https://kubernetes.io/docs/reference/using-api/api-concepts/#semantics-for-get-and-list),
+            request_timeout: HTTP-level timeout override for this call. A number is
+                interpreted as the total timeout in seconds. Pass ``None`` to disable
+                timeouts entirely for this call. Omit to use the client default.
         Returns:
             ResourceType: the resource instance.
         """
         _namespace = self._ensure_required_namespace(namespace)
         options = GetOptions(resource_version=resource_version)
-        request = self._request_builder.get(name, _namespace, options)
+        request = apply_request_timeout(
+            self._request_builder.get(name, _namespace, options), request_timeout
+        )
         response = await self._client.request(request)
         return self._resource.model_validate_json(response.content)
 
@@ -134,6 +140,7 @@ class Api(Generic[ResourceType], MetadataMixin[ResourceType], LogsMixin[Resource
         continue_token: str | None = None,
         version_match: VersionMatch | None = None,
         resource_version: ResourceVersionTypes = None,
+        request_timeout: ApiRequestTimeoutTypes = Ellipsis,
     ) -> ListEntity[ResourceType]:
         """List objects of kind.
 
@@ -145,13 +152,18 @@ class Api(Generic[ResourceType], MetadataMixin[ResourceType], LogsMixin[Resource
                 For details look at [Label Selectors documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors).
             field_selector: A selector to restrict the list of returned objects by their fields.
                 For details look at [Field Selectors documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/).
-            timeout: Timeout for the list/watch call.
+            timeout: Server-side timeout (in seconds) for the list/watch call;
+                sent as the Kubernetes ``timeoutSeconds`` query parameter. For an
+                HTTP client-side timeout, use ``request_timeout``.
             limit: The maximum number of items to return.
             continue_token: The continue token for the list call.
             version_match: Whether to watch for changes to a resource.
             resource_version: The resource version to list. If not provided,
                 the current resource version will be listed. For details look at
                 [Resource Version Semantics documentation](https://kubernetes.io/docs/reference/using-api/api-concepts/#semantics-for-get-and-list),
+            request_timeout: HTTP-level timeout override for this call. A number is
+                interpreted as the total timeout in seconds. Pass ``None`` to disable
+                timeouts entirely for this call. Omit to use the client default.
         Returns:
             ListEntity[ResourceType]: the list of resource.
         """
@@ -165,7 +177,9 @@ class Api(Generic[ResourceType], MetadataMixin[ResourceType], LogsMixin[Resource
             version_match=version_match,
             resource_version=resource_version,
         )
-        request = self._request_builder.list(_namespace, options)
+        request = apply_request_timeout(
+            self._request_builder.list(_namespace, options), request_timeout
+        )
         response = await self._client.request(request)
         list_model = self._resource.__RESOURCE_CONFIG__.list_model
         return list_model.model_validate_json(response.content)
@@ -177,6 +191,7 @@ class Api(Generic[ResourceType], MetadataMixin[ResourceType], LogsMixin[Resource
         namespace: ApiNamespaceTypes = Ellipsis,
         dry_run: DryRunTypes = None,
         field_manager: str | None = None,
+        request_timeout: ApiRequestTimeoutTypes = Ellipsis,
     ) -> ResourceType:
         """Create a resource.
 
@@ -188,15 +203,23 @@ class Api(Generic[ResourceType], MetadataMixin[ResourceType], LogsMixin[Resource
                 If namespace is provided for cluster-scoped resources, an error will be raised.
             dry_run: Whether to perform a dry run of the operation.
             field_manager (str): The value to use for the fieldManager attribute of the created resource.
+            request_timeout: HTTP-level timeout override for this call. A number is
+                interpreted as the total timeout in seconds. Pass ``None`` to disable
+                timeouts entirely for this call. Omit to use the client default.
         Returns:
             ResourceType: the created resource instance.
         """
         _namespace = self._ensure_required_namespace(namespace)
         options = PostOptions(dry_run=dry_run, field_manager=field_manager)
-        request = self._request_builder.create(
-            _namespace,
-            options,
-            data.model_dump_json(by_alias=True, exclude_unset=True, exclude_none=True),
+        request = apply_request_timeout(
+            self._request_builder.create(
+                _namespace,
+                options,
+                data.model_dump_json(
+                    by_alias=True, exclude_unset=True, exclude_none=True
+                ),
+            ),
+            request_timeout,
         )
         response = await self._client.request(request)
         return self._resource.model_validate_json(response.content)
@@ -210,6 +233,7 @@ class Api(Generic[ResourceType], MetadataMixin[ResourceType], LogsMixin[Resource
         grace_period_seconds: int | None = None,
         propagation_policy: PropagationPolicyTypes = None,
         preconditions: Precondition | None = None,
+        request_timeout: ApiRequestTimeoutTypes = Ellipsis,
     ) -> Status | ResourceType:
         """Delete the specified resource.
 
@@ -223,6 +247,9 @@ class Api(Generic[ResourceType], MetadataMixin[ResourceType], LogsMixin[Resource
             grace_period_seconds: The duration in seconds before the object should be deleted.
             propagation_policy: Whether and how garbage collection will be performed.
             preconditions: Preconditions for the operation.
+            request_timeout: HTTP-level timeout override for this call. A number is
+                interpreted as the total timeout in seconds. Pass ``None`` to disable
+                timeouts entirely for this call. Omit to use the client default.
         Returns:
             Status: the resource has been fully deleted.
             ResourceType: the resource instance deletion process has started,
@@ -237,7 +264,9 @@ class Api(Generic[ResourceType], MetadataMixin[ResourceType], LogsMixin[Resource
             propagation_policy=propagation_policy,
             preconditions=preconditions,
         )
-        request = self._request_builder.delete(name, _namespace, options)
+        request = apply_request_timeout(
+            self._request_builder.delete(name, _namespace, options), request_timeout
+        )
         response = await self._client.request(request)
         try:
             return Status.model_validate_json(response.content)
@@ -259,8 +288,15 @@ class Api(Generic[ResourceType], MetadataMixin[ResourceType], LogsMixin[Resource
         grace_period_seconds: int | None = None,
         propagation_policy: PropagationPolicyTypes = None,
         preconditions: Precondition | None = None,
+        request_timeout: ApiRequestTimeoutTypes = Ellipsis,
     ) -> Status | ListEntity[ResourceType]:
-        """Delete collection of resources."""
+        """Delete collection of resources.
+
+        Args:
+            request_timeout: HTTP-level timeout override for this call. A number is
+                interpreted as the total timeout in seconds. Pass ``None`` to disable
+                timeouts entirely for this call. Omit to use the client default.
+        """
         _namespace = self._ensure_optional_namespace(namespace)
         list_options = ListOptions(
             label_selector=label_selector,
@@ -277,8 +313,11 @@ class Api(Generic[ResourceType], MetadataMixin[ResourceType], LogsMixin[Resource
             propagation_policy=propagation_policy,
             preconditions=preconditions,
         )
-        request = self._request_builder.delete_collection(
-            _namespace, list_options, delete_options
+        request = apply_request_timeout(
+            self._request_builder.delete_collection(
+                _namespace, list_options, delete_options
+            ),
+            request_timeout,
         )
         response = await self._client.request(request)
         list_model = self._resource.__RESOURCE_CONFIG__.list_model
@@ -297,8 +336,15 @@ class Api(Generic[ResourceType], MetadataMixin[ResourceType], LogsMixin[Resource
         field_manager: str | None = None,
         force: bool | None = None,
         field_validation: FieldValidation | None = None,
+        request_timeout: ApiRequestTimeoutTypes = Ellipsis,
     ) -> ResourceType:
-        """Patch the specified resource."""
+        """Patch the specified resource.
+
+        Args:
+            request_timeout: HTTP-level timeout override for this call. A number is
+                interpreted as the total timeout in seconds. Pass ``None`` to disable
+                timeouts entirely for this call. Omit to use the client default.
+        """
         _namespace = self._ensure_required_namespace(namespace)
         options = PatchOptions(
             dry_run=dry_run,
@@ -306,7 +352,10 @@ class Api(Generic[ResourceType], MetadataMixin[ResourceType], LogsMixin[Resource
             force=force,
             field_validation=field_validation,
         )
-        request = self._request_builder.patch(name, _namespace, options, patch)
+        request = apply_request_timeout(
+            self._request_builder.patch(name, _namespace, options, patch),
+            request_timeout,
+        )
         response = await self._client.request(request)
         return self._resource.model_validate_json(response.content)
 
@@ -318,15 +367,27 @@ class Api(Generic[ResourceType], MetadataMixin[ResourceType], LogsMixin[Resource
         namespace: ApiNamespaceTypes = Ellipsis,
         dry_run: DryRunTypes = None,
         field_manager: str | None = None,
+        request_timeout: ApiRequestTimeoutTypes = Ellipsis,
     ) -> ResourceType:
-        """Replace the specified resource."""
+        """Replace the specified resource.
+
+        Args:
+            request_timeout: HTTP-level timeout override for this call. A number is
+                interpreted as the total timeout in seconds. Pass ``None`` to disable
+                timeouts entirely for this call. Omit to use the client default.
+        """
         _namespace = self._ensure_required_namespace(namespace)
         options = PostOptions(dry_run=dry_run, field_manager=field_manager)
-        request = self._request_builder.replace(
-            name,
-            _namespace,
-            options,
-            data.model_dump_json(by_alias=True, exclude_unset=True, exclude_none=True),
+        request = apply_request_timeout(
+            self._request_builder.replace(
+                name,
+                _namespace,
+                options,
+                data.model_dump_json(
+                    by_alias=True, exclude_unset=True, exclude_none=True
+                ),
+            ),
+            request_timeout,
         )
         response = await self._client.request(request)
         return self._resource.model_validate_json(response.content)
@@ -341,8 +402,17 @@ class Api(Generic[ResourceType], MetadataMixin[ResourceType], LogsMixin[Resource
         send_initial_events: bool | None = None,
         timeout_seconds: int | None = None,
         resource_version: ResourceVersionTypes = None,
+        request_timeout: ApiRequestTimeoutTypes = Ellipsis,
     ) -> AsyncGenerator[WatchEvent[ResourceType], None]:
-        """Watch for changes to the specified resource."""
+        """Watch for changes to the specified resource.
+
+        Args:
+            request_timeout: HTTP-level timeout override for this call. A number is
+                interpreted as the total timeout in seconds. Pass ``None`` to disable
+                timeouts entirely for this call. Omit to use the client default. For
+                long-lived watches a short read/total timeout will terminate the
+                stream; disable the read timeout or leave this unset.
+        """
         _namespace = self._ensure_optional_namespace(namespace)
         options = WatchOptions(
             label_selector=label_selector,
@@ -351,8 +421,11 @@ class Api(Generic[ResourceType], MetadataMixin[ResourceType], LogsMixin[Resource
             send_initial_events=send_initial_events,
             timeout_seconds=timeout_seconds,
         )
-        request = self._request_builder.watch(
-            _namespace, options, resource_version=resource_version
+        request = apply_request_timeout(
+            self._request_builder.watch(
+                _namespace, options, resource_version=resource_version
+            ),
+            request_timeout,
         )
         async for line in self._client.stream_lines(request):
             yield WatchEvent(self._resource, json.loads(line))

--- a/kubex/client/aiohttp.py
+++ b/kubex/client/aiohttp.py
@@ -1,11 +1,12 @@
 import ssl
 import warnings
-from typing import AsyncGenerator
+from typing import Any, AsyncGenerator
 
-from aiohttp import ClientSession
+from aiohttp import ClientSession, ClientTimeout
 from aiohttp.connector import TCPConnector
 
 from kubex.configuration import ClientConfiguration
+from kubex.core.params import Timeout
 from kubex.core.request import Request
 from kubex.core.request_builder import constants
 from kubex.core.response import HeadersWrapper, Response
@@ -14,6 +15,20 @@ from .client import (
     BaseClient,
     handle_request_error,
 )
+
+
+def _to_aiohttp_timeout(timeout: Timeout | None) -> ClientTimeout:
+    """Translate a ``Timeout`` (or explicit ``None``) to ``ClientTimeout``.
+
+    ``write`` and ``pool`` are ignored: aiohttp does not support them.
+    """
+    if timeout is None:
+        return ClientTimeout(total=None)
+    return ClientTimeout(
+        total=timeout.total,
+        connect=timeout.connect,
+        sock_read=timeout.read,
+    )
 
 
 class AioHttpClient(BaseClient):
@@ -54,23 +69,31 @@ class AioHttpClient(BaseClient):
             verify_ssl=not bool(self.configuration.insecure_skip_tls_verify),
             ssl=ssl_context,
         )
-        return ClientSession(
-            base_url=str(self.configuration.base_url),
-            connector=connector,
-            read_bufsize=2**21,
-            headers=self._default_headers,
-        )
+        kwargs: dict[str, Any] = {
+            "base_url": str(self.configuration.base_url),
+            "connector": connector,
+            "read_bufsize": 2**21,
+            "headers": self._default_headers,
+        }
+        configured_timeout = self.configuration.timeout
+        if configured_timeout is not Ellipsis:
+            kwargs["timeout"] = _to_aiohttp_timeout(configured_timeout)
+        return ClientSession(**kwargs)
 
     async def request(self, request: Request) -> Response:
         headers = self._get_headers()
         if request.headers:
             headers.update(request.headers)
+        extra: dict[str, Any] = {}
+        if request.timeout is not Ellipsis:
+            extra["timeout"] = _to_aiohttp_timeout(request.timeout)
         _response = await self._inner_client.request(
             method=request.method,
             url=request.url,
             params=request.query_params,
             data=request.body,
             headers=headers,
+            **extra,
         )
         status = _response.status
         response = Response(
@@ -91,12 +114,16 @@ class AioHttpClient(BaseClient):
         headers = self._get_headers()
         if request.headers:
             headers.update(request.headers)
+        extra: dict[str, Any] = {}
+        if request.timeout is not Ellipsis:
+            extra["timeout"] = _to_aiohttp_timeout(request.timeout)
         _response = await self._inner_client.request(
             method=request.method,
             url=request.url,
             params=request.query_params,
             data=request.body,
             headers=request.headers,
+            **extra,
         )
         status = _response.status
         if 400 <= status < 600:

--- a/kubex/client/aiohttp.py
+++ b/kubex/client/aiohttp.py
@@ -26,7 +26,7 @@ def _to_aiohttp_timeout(timeout: Timeout | None) -> ClientTimeout:
         return ClientTimeout(total=None)
     return ClientTimeout(
         total=timeout.total,
-        connect=timeout.connect,
+        sock_connect=timeout.connect,
         sock_read=timeout.read,
     )
 
@@ -122,7 +122,7 @@ class AioHttpClient(BaseClient):
             url=request.url,
             params=request.query_params,
             data=request.body,
-            headers=request.headers,
+            headers=headers,
             **extra,
         )
         status = _response.status

--- a/kubex/client/httpx.py
+++ b/kubex/client/httpx.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import ssl
 import warnings
-from typing import AsyncGenerator
+from typing import Any, AsyncGenerator
 
 import httpx
 
 from kubex.configuration import ClientConfiguration
+from kubex.core.params import Timeout
 from kubex.core.request import Request
 from kubex.core.response import HeadersWrapper, Response
 
@@ -14,6 +15,19 @@ from .client import (
     BaseClient,
     handle_request_error,
 )
+
+
+def _to_httpx_timeout(timeout: Timeout | None) -> httpx.Timeout:
+    """Translate a ``Timeout`` (or explicit ``None``) to an ``httpx.Timeout``."""
+    if timeout is None:
+        return httpx.Timeout(None)
+    return httpx.Timeout(
+        timeout.total,
+        connect=timeout.connect if timeout.connect is not None else timeout.total,
+        read=timeout.read if timeout.read is not None else timeout.total,
+        write=timeout.write if timeout.write is not None else timeout.total,
+        pool=timeout.pool if timeout.pool is not None else timeout.total,
+    )
 
 
 class HttpxClient(BaseClient):
@@ -47,21 +61,29 @@ class HttpxClient(BaseClient):
         else:
             _verify = True
 
-        return httpx.AsyncClient(
-            base_url=str(self.configuration.base_url),
-            verify=_verify,
-        )
+        kwargs: dict[str, Any] = {
+            "base_url": str(self.configuration.base_url),
+            "verify": _verify,
+        }
+        configured_timeout = self.configuration.timeout
+        if configured_timeout is not Ellipsis:
+            kwargs["timeout"] = _to_httpx_timeout(configured_timeout)
+        return httpx.AsyncClient(**kwargs)
 
     async def request(self, request: Request) -> Response:
         headers = self._get_headers()
         if request.headers:
             headers.update(request.headers)
+        extra: dict[str, Any] = {}
+        if request.timeout is not Ellipsis:
+            extra["timeout"] = _to_httpx_timeout(request.timeout)
         _response = await self._inner_client.request(
             method=request.method,
             url=request.url,
             params=request.query_params,
             content=request.body,
             headers=headers,
+            **extra,
         )
         status = _response.status_code
         response = Response(
@@ -82,12 +104,16 @@ class HttpxClient(BaseClient):
         headers = self._get_headers()
         if request.headers:
             headers.update(request.headers)
+        extra: dict[str, Any] = {}
+        if request.timeout is not Ellipsis:
+            extra["timeout"] = _to_httpx_timeout(request.timeout)
         async with self._inner_client.stream(
             method=request.method,
             url=request.url,
             params=request.query_params,
             content=request.body,
             headers=headers,
+            **extra,
         ) as _response:
             status = _response.status_code
             if 400 <= status < 600:

--- a/kubex/configuration/configuration.py
+++ b/kubex/configuration/configuration.py
@@ -2,9 +2,11 @@ import typing
 from enum import Enum
 from pathlib import Path
 from time import time
+from types import EllipsisType
 
 from pydantic import Field, FilePath, HttpUrl, SecretStr
 
+from kubex.core.params import Timeout, TimeoutTypes
 from kubex_core.models.base import BaseK8sModel
 
 
@@ -205,6 +207,7 @@ class ClientConfiguration:
         namespace: str | None = None,
         try_refresh_token: bool = False,
         log_api_warnings: bool = True,
+        timeout: TimeoutTypes | EllipsisType = ...,
     ) -> None:
         if try_refresh_token and token_file is None:
             raise ValueError("Token file must be provided to refresh token")
@@ -233,6 +236,19 @@ class ClientConfiguration:
         self._last_token_read: float | None = None
         self._current_token: str | None = None
         self._token = token
+        self._timeout: Timeout | None | EllipsisType = (
+            timeout if timeout is Ellipsis else Timeout.coerce(timeout)
+        )
+
+    @property
+    def timeout(self) -> Timeout | None | EllipsisType:
+        """Default HTTP timeout for this client.
+
+        ``Ellipsis`` means no timeout was configured (backend library default
+        applies). ``None`` means timeouts are explicitly disabled. A
+        :class:`Timeout` instance is used as-is.
+        """
+        return self._timeout
 
     @property
     def verify(self) -> bool | str | None:

--- a/kubex/core/params.py
+++ b/kubex/core/params.py
@@ -71,7 +71,7 @@ class Timeout:
         return hash((self.total, self.connect, self.read, self.write, self.pool))
 
 
-TimeoutTypes = Union["Timeout", float, int, None]
+TimeoutTypes = Union[Timeout, float, int, None]
 
 
 class VersionMatch(str, Enum):

--- a/kubex/core/params.py
+++ b/kubex/core/params.py
@@ -2,8 +2,76 @@ from __future__ import annotations
 
 import json
 from enum import Enum
-from typing import Any, Literal
+from typing import Any, Literal, Union
 from uuid import UUID
+
+
+class Timeout:
+    """Timeout settings for HTTP requests.
+
+    Provides a client-agnostic way to configure timeout settings for the
+    underlying HTTP client. Individual fields may be ignored by a given
+    implementation if the client library does not support them.
+
+    Args:
+        total: Total timeout in seconds for the whole request. Used as the
+            default for unset granular fields.
+        connect: Timeout in seconds for establishing a connection.
+        read: Timeout in seconds for reading the response.
+        write: Timeout in seconds for writing the request body.
+            Only honored by the httpx backend.
+        pool: Timeout in seconds for acquiring a connection from the pool.
+            Only honored by the httpx backend.
+    """
+
+    __slots__ = ("total", "connect", "read", "write", "pool")
+
+    def __init__(
+        self,
+        total: float | None = None,
+        *,
+        connect: float | None = None,
+        read: float | None = None,
+        write: float | None = None,
+        pool: float | None = None,
+    ) -> None:
+        self.total = total
+        self.connect = connect
+        self.read = read
+        self.write = write
+        self.pool = pool
+
+    @classmethod
+    def coerce(cls, value: TimeoutTypes) -> Timeout | None:
+        """Normalize a ``TimeoutTypes`` value to ``Timeout`` or ``None``."""
+        if value is None:
+            return None
+        if isinstance(value, Timeout):
+            return value
+        return cls(total=float(value))
+
+    def __repr__(self) -> str:
+        return (
+            f"Timeout(total={self.total}, connect={self.connect}, "
+            f"read={self.read}, write={self.write}, pool={self.pool})"
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Timeout):
+            return NotImplemented
+        return (
+            self.total == other.total
+            and self.connect == other.connect
+            and self.read == other.read
+            and self.write == other.write
+            and self.pool == other.pool
+        )
+
+    def __hash__(self) -> int:
+        return hash((self.total, self.connect, self.read, self.write, self.pool))
+
+
+TimeoutTypes = Union["Timeout", float, int, None]
 
 
 class VersionMatch(str, Enum):

--- a/kubex/core/request.py
+++ b/kubex/core/request.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from types import EllipsisType
+
+from kubex.core.params import Timeout
+
 
 class Request:
     def __init__(
@@ -9,12 +13,18 @@ class Request:
         query_params: dict[str, str] | None = None,
         body: str | bytes | None = None,
         headers: dict[str, str] | None = None,
+        timeout: Timeout | None | EllipsisType = ...,
     ) -> None:
         self.url = url
         self.query_params = query_params
         self.method = method
         self.body = body
         self.headers = headers
+        self.timeout: Timeout | None | EllipsisType = timeout
 
     def __repr__(self) -> str:
-        return f"Request(method={self.method}, url={self.url}, query_params={self.query_params}, body={self.body!r}, headers={self.headers})"
+        return (
+            f"Request(method={self.method}, url={self.url}, "
+            f"query_params={self.query_params}, body={self.body!r}, "
+            f"headers={self.headers}, timeout={self.timeout!r})"
+        )

--- a/kubex/core/request.py
+++ b/kubex/core/request.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from types import EllipsisType
 
-from kubex.core.params import Timeout
+from kubex.core.params import Timeout, TimeoutTypes
 
 
 class Request:
@@ -13,14 +13,16 @@ class Request:
         query_params: dict[str, str] | None = None,
         body: str | bytes | None = None,
         headers: dict[str, str] | None = None,
-        timeout: Timeout | None | EllipsisType = ...,
+        timeout: TimeoutTypes | EllipsisType = ...,
     ) -> None:
         self.url = url
         self.query_params = query_params
         self.method = method
         self.body = body
         self.headers = headers
-        self.timeout: Timeout | None | EllipsisType = timeout
+        self.timeout: Timeout | None | EllipsisType = (
+            timeout if timeout is Ellipsis else Timeout.coerce(timeout)
+        )
 
     def __repr__(self) -> str:
         return (

--- a/kubex/core/request_builder/builder.py
+++ b/kubex/core/request_builder/builder.py
@@ -1,3 +1,4 @@
+from types import EllipsisType
 from typing import Any
 
 from kubex.core.params import (
@@ -6,6 +7,7 @@ from kubex.core.params import (
     ListOptions,
     PatchOptions,
     PostOptions,
+    TimeoutTypes,
     WatchOptions,
 )
 from kubex.core.patch import Patch
@@ -24,24 +26,44 @@ class RequestBuilder(
     def __init__(self, resource_config: ResourceConfig[Any]) -> None:
         self.resource_config = resource_config
 
-    def get(self, name: str, namespace: str | None, options: GetOptions) -> Request:
+    def get(
+        self,
+        name: str,
+        namespace: str | None,
+        options: GetOptions,
+        *,
+        request_timeout: TimeoutTypes | EllipsisType = ...,
+    ) -> Request:
         query_params = options.as_query_params()
         return Request(
             method="GET",
             url=self.resource_config.url(namespace, name),
             query_params=query_params,
+            timeout=request_timeout,
         )
 
-    def list(self, namespace: str | None, options: ListOptions) -> Request:
+    def list(
+        self,
+        namespace: str | None,
+        options: ListOptions,
+        *,
+        request_timeout: TimeoutTypes | EllipsisType = ...,
+    ) -> Request:
         query_params = options.as_query_params()
         return Request(
             method="GET",
             url=self.resource_config.url(namespace),
             query_params=query_params,
+            timeout=request_timeout,
         )
 
     def create(
-        self, namespace: str | None, options: PostOptions, data: str | bytes
+        self,
+        namespace: str | None,
+        options: PostOptions,
+        data: str | bytes,
+        *,
+        request_timeout: TimeoutTypes | EllipsisType = ...,
     ) -> Request:
         query_params = options.as_query_params()
         return Request(
@@ -49,20 +71,32 @@ class RequestBuilder(
             url=self.resource_config.url(namespace),
             query_params=query_params,
             body=data,
+            timeout=request_timeout,
         )
 
     def delete(
-        self, name: str, namespace: str | None, options: DeleteOptions
+        self,
+        name: str,
+        namespace: str | None,
+        options: DeleteOptions,
+        *,
+        request_timeout: TimeoutTypes | EllipsisType = ...,
     ) -> Request:
         body = options.as_request_body()
         return Request(
             method="DELETE",
             url=self.resource_config.url(namespace, name),
             body=body,
+            timeout=request_timeout,
         )
 
     def delete_collection(
-        self, namespace: str | None, options: ListOptions, delete_options: DeleteOptions
+        self,
+        namespace: str | None,
+        options: ListOptions,
+        delete_options: DeleteOptions,
+        *,
+        request_timeout: TimeoutTypes | EllipsisType = ...,
     ) -> Request:
         query_params = options.as_query_params()
         body = delete_options.as_request_body()
@@ -71,10 +105,17 @@ class RequestBuilder(
             url=self.resource_config.url(namespace),
             query_params=query_params,
             body=body,
+            timeout=request_timeout,
         )
 
     def patch(
-        self, name: str, namespace: str | None, options: PatchOptions, patch: Patch
+        self,
+        name: str,
+        namespace: str | None,
+        options: PatchOptions,
+        patch: Patch,
+        *,
+        request_timeout: TimeoutTypes | EllipsisType = ...,
     ) -> Request:
         return Request(
             method="PATCH",
@@ -85,10 +126,17 @@ class RequestBuilder(
                 ACCEPT_HEADER: APPLICATION_JSON_MIME_TYPE,
                 CONTENT_TYPE_HEADER: patch.content_type_header,
             },
+            timeout=request_timeout,
         )
 
     def replace(
-        self, name: str, namespace: str | None, options: PostOptions, data: str | bytes
+        self,
+        name: str,
+        namespace: str | None,
+        options: PostOptions,
+        data: str | bytes,
+        *,
+        request_timeout: TimeoutTypes | EllipsisType = ...,
     ) -> Request:
         query_params = options.as_query_params()
         return Request(
@@ -96,6 +144,7 @@ class RequestBuilder(
             url=self.resource_config.url(namespace, name),
             query_params=query_params,
             body=data,
+            timeout=request_timeout,
         )
 
     def watch(
@@ -103,6 +152,8 @@ class RequestBuilder(
         namespace: str | None,
         options: WatchOptions,
         resource_version: str | None = None,
+        *,
+        request_timeout: TimeoutTypes | EllipsisType = ...,
     ) -> Request:
         query_params = options.as_query_params()
         if resource_version is not None:
@@ -111,4 +162,5 @@ class RequestBuilder(
             method="GET",
             url=self.resource_config.url(namespace),
             query_params=query_params,
+            timeout=request_timeout,
         )

--- a/kubex/core/request_builder/logs.py
+++ b/kubex/core/request_builder/logs.py
@@ -1,6 +1,9 @@
+from types import EllipsisType
+
 from kubex.core.params import (
     LogOptions,
     NamespaceTypes,
+    TimeoutTypes,
 )
 from kubex.core.request import Request
 from kubex.core.request_builder.subresource import RequestBuilderProtocol
@@ -8,17 +11,28 @@ from kubex.core.request_builder.subresource import RequestBuilderProtocol
 
 class LogsRequestBuilder(RequestBuilderProtocol):
     def logs(
-        self, name: str, namespace: NamespaceTypes, options: LogOptions
+        self,
+        name: str,
+        namespace: NamespaceTypes,
+        options: LogOptions,
+        *,
+        request_timeout: TimeoutTypes | EllipsisType = ...,
     ) -> Request:
         query_params = options.as_query_params()
         return Request(
             method="GET",
             url=f"{self.resource_config.url(namespace, name)}/log",
             query_params=query_params,
+            timeout=request_timeout,
         )
 
     def stream_logs(
-        self, name: str, namespace: NamespaceTypes, options: LogOptions
+        self,
+        name: str,
+        namespace: NamespaceTypes,
+        options: LogOptions,
+        *,
+        request_timeout: TimeoutTypes | EllipsisType = ...,
     ) -> Request:
         query_params = options.as_query_params()
         if query_params is None:
@@ -29,4 +43,5 @@ class LogsRequestBuilder(RequestBuilderProtocol):
             method="GET",
             url=f"{self.resource_config.url(namespace, name)}/log",
             query_params=query_params,
+            timeout=request_timeout,
         )

--- a/kubex/core/request_builder/metadata.py
+++ b/kubex/core/request_builder/metadata.py
@@ -1,8 +1,11 @@
+from types import EllipsisType
+
 from kubex.core.params import (
     GetOptions,
     ListOptions,
     NamespaceTypes,
     PatchOptions,
+    TimeoutTypes,
     WatchOptions,
 )
 from kubex.core.patch import Patch
@@ -19,7 +22,12 @@ from kubex.core.request_builder.subresource import RequestBuilderProtocol
 
 class MetadataRequestBuilder(RequestBuilderProtocol):
     def get_metadata(
-        self, name: str, namespace: NamespaceTypes, options: GetOptions
+        self,
+        name: str,
+        namespace: NamespaceTypes,
+        options: GetOptions,
+        *,
+        request_timeout: TimeoutTypes | EllipsisType = ...,
     ) -> Request:
         query_params = options.as_query_params()
         headers = {
@@ -31,9 +39,16 @@ class MetadataRequestBuilder(RequestBuilderProtocol):
             url=self.resource_config.url(namespace, name),
             query_params=query_params,
             headers=headers,
+            timeout=request_timeout,
         )
 
-    def list_metadata(self, namespace: NamespaceTypes, options: ListOptions) -> Request:
+    def list_metadata(
+        self,
+        namespace: NamespaceTypes,
+        options: ListOptions,
+        *,
+        request_timeout: TimeoutTypes | EllipsisType = ...,
+    ) -> Request:
         query_params = options.as_query_params()
         headers = {
             ACCEPT_HEADER: METADATA_LIST_MIME_TYPE,
@@ -44,6 +59,7 @@ class MetadataRequestBuilder(RequestBuilderProtocol):
             url=self.resource_config.url(namespace),
             query_params=query_params,
             headers=headers,
+            timeout=request_timeout,
         )
 
     def watch_metadata(
@@ -51,6 +67,8 @@ class MetadataRequestBuilder(RequestBuilderProtocol):
         namespace: NamespaceTypes,
         options: WatchOptions,
         resource_version: str | None = None,
+        *,
+        request_timeout: TimeoutTypes | EllipsisType = ...,
     ) -> Request:
         query_params = options.as_query_params()
         if resource_version is not None:
@@ -64,10 +82,17 @@ class MetadataRequestBuilder(RequestBuilderProtocol):
             url=self.resource_config.url(namespace),
             query_params=query_params,
             headers=headers,
+            timeout=request_timeout,
         )
 
     def patch_metadata(
-        self, name: str, namespace: NamespaceTypes, options: PatchOptions, patch: Patch
+        self,
+        name: str,
+        namespace: NamespaceTypes,
+        options: PatchOptions,
+        patch: Patch,
+        *,
+        request_timeout: TimeoutTypes | EllipsisType = ...,
     ) -> Request:
         return Request(
             method="PATCH",
@@ -78,4 +103,5 @@ class MetadataRequestBuilder(RequestBuilderProtocol):
                 CONTENT_TYPE_HEADER: patch.content_type_header,
             },
             body=patch.serialize(),
+            timeout=request_timeout,
         )

--- a/kubex/core/request_builder/subresource.py
+++ b/kubex/core/request_builder/subresource.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
 import typing
+from types import EllipsisType
 
-from kubex.core.params import NamespaceTypes, PatchOptions, PostOptions
+from kubex.core.params import (
+    NamespaceTypes,
+    PatchOptions,
+    PostOptions,
+    TimeoutTypes,
+)
 from kubex.core.patch import Patch
 from kubex.core.request import Request
 from kubex_core.models.resource_config import ResourceConfig
@@ -20,11 +26,17 @@ class RequestBuilderProtocol(typing.Protocol):
 
 class SubresourceRequestBuilder(RequestBuilderProtocol):
     def get_subresource(
-        self, subresource: str, name: str, namespace: NamespaceTypes
+        self,
+        subresource: str,
+        name: str,
+        namespace: NamespaceTypes,
+        *,
+        request_timeout: TimeoutTypes | EllipsisType = ...,
     ) -> Request:
         return Request(
             method="GET",
             url=self.resource_config.url(namespace, name) + f"/{subresource}",
+            timeout=request_timeout,
         )
 
     def replace_subresource(
@@ -34,12 +46,15 @@ class SubresourceRequestBuilder(RequestBuilderProtocol):
         namespace: NamespaceTypes,
         data: bytes | str,
         options: PostOptions,
+        *,
+        request_timeout: TimeoutTypes | EllipsisType = ...,
     ) -> Request:
         return Request(
             method="PUT",
             url=self.resource_config.url(namespace, name) + f"/{subresource}",
             body=data,
             query_params=options.as_query_params(),
+            timeout=request_timeout,
         )
 
     def patch_subresource(
@@ -49,6 +64,8 @@ class SubresourceRequestBuilder(RequestBuilderProtocol):
         namespace: NamespaceTypes,
         options: PatchOptions,
         patch: Patch,
+        *,
+        request_timeout: TimeoutTypes | EllipsisType = ...,
     ) -> Request:
         return Request(
             method="PATCH",
@@ -59,4 +76,5 @@ class SubresourceRequestBuilder(RequestBuilderProtocol):
                 CONTENT_TYPE_HEADER: patch.content_type_header,
             },
             query_params=options.as_query_params(),
+            timeout=request_timeout,
         )

--- a/test/test_timeout/conftest.py
+++ b/test/test_timeout/conftest.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import Any, AsyncGenerator, Iterable
+
+import pytest
+
+from kubex.client.client import BaseClient
+from kubex.configuration import ClientConfiguration
+from kubex.core.request import Request
+from kubex.core.response import HeadersWrapper, Response
+
+
+class StubClient(BaseClient):
+    """A minimal ``BaseClient`` that records requests and returns canned bytes.
+
+    Used by the ``request_timeout`` flow tests to assert that the value passed
+    to an ``Api`` method is attached to the outgoing ``Request``.
+    """
+
+    def __init__(
+        self,
+        configuration: ClientConfiguration | None = None,
+        *,
+        response_content: bytes = b"{}",
+        status_code: int = 200,
+        stream_lines: Iterable[str] = (),
+    ) -> None:
+        self._configuration = configuration or ClientConfiguration(
+            url="https://example.invalid",
+            insecure_skip_tls_verify=True,
+        )
+        self._inner_client = object()
+        self.requests: list[Request] = []
+        self._response_content = response_content
+        self._status_code = status_code
+        self._stream_lines = list(stream_lines)
+
+    def _create_inner_client(self) -> Any:
+        return object()
+
+    async def __aenter__(self) -> "StubClient":
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        return None
+
+    async def request(self, request: Request) -> Response:
+        self.requests.append(request)
+        return Response(
+            content=self._response_content,
+            headers=HeadersWrapper({}),
+            status_code=self._status_code,
+        )
+
+    async def stream_lines(self, request: Request) -> AsyncGenerator[str, None]:
+        self.requests.append(request)
+        for line in self._stream_lines:
+            yield line
+
+    async def close(self) -> None:
+        return None
+
+    @property
+    def last_request(self) -> Request:
+        assert self.requests, "StubClient received no requests"
+        return self.requests[-1]
+
+
+@pytest.fixture
+def stub_client() -> StubClient:
+    return StubClient()
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"

--- a/test/test_timeout/test_aiohttp_client.py
+++ b/test/test_timeout/test_aiohttp_client.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import pytest
+
+from kubex.configuration import ClientConfiguration
+from kubex.core.params import Timeout
+
+aiohttp = pytest.importorskip("aiohttp")
+
+from kubex.client.aiohttp import AioHttpClient, _to_aiohttp_timeout  # noqa: E402
+
+
+def _configuration(**kwargs: object) -> ClientConfiguration:
+    # Leave ``insecure_skip_tls_verify`` unset so the aiohttp connector builds a
+    # valid ``SSLContext`` (the code path would otherwise combine
+    # ``verify_ssl=False`` with an ``ssl`` context and raise).
+    return ClientConfiguration(
+        url="https://example.invalid",
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+@pytest.mark.anyio
+async def test_create_inner_session_with_timeout() -> None:
+    client = AioHttpClient(_configuration(timeout=5))
+    try:
+        assert client._inner_client.timeout.total == 5
+    finally:
+        await client.close()
+
+
+@pytest.mark.anyio
+async def test_create_inner_session_with_none_disables_timeout() -> None:
+    client = AioHttpClient(_configuration(timeout=None))
+    try:
+        assert client._inner_client.timeout.total is None
+    finally:
+        await client.close()
+
+
+def test_to_aiohttp_timeout_maps_read_to_sock_read() -> None:
+    translated = _to_aiohttp_timeout(
+        Timeout(total=5, connect=1, read=2, write=3, pool=4)
+    )
+    assert translated.total == 5
+    assert translated.connect == 1
+    assert translated.sock_read == 2
+
+
+def test_to_aiohttp_timeout_none_means_disabled() -> None:
+    translated = _to_aiohttp_timeout(None)
+    assert translated.total is None

--- a/test/test_timeout/test_aiohttp_client.py
+++ b/test/test_timeout/test_aiohttp_client.py
@@ -43,7 +43,7 @@ def test_to_aiohttp_timeout_maps_read_to_sock_read() -> None:
         Timeout(total=5, connect=1, read=2, write=3, pool=4)
     )
     assert translated.total == 5
-    assert translated.connect == 1
+    assert translated.sock_connect == 1
     assert translated.sock_read == 2
 
 

--- a/test/test_timeout/test_api_overrides.py
+++ b/test/test_timeout/test_api_overrides.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Type
+
+import pytest
+
+from kubex.api import Api
+from kubex.api._subressource import ScaleMixin
+from kubex.core.params import NamespaceTypes, Timeout
+from kubex.core.patch import MergePatch
+from kubex.core.request_builder.builder import RequestBuilder
+from kubex.k8s.v1_35.apps.v1.deployment import Deployment
+from kubex.k8s.v1_35.core.v1.pod import Pod
+
+from .conftest import StubClient
+
+
+class _ScaleOnly(ScaleMixin[Deployment]):
+    """Minimal ScaleMixin host used only for timeout-flow testing.
+
+    Avoids the ``_check_implemented`` name collision between ``LogsMixin`` and
+    ``ScaleMixin`` that would otherwise bite us if we composed with ``Api``.
+    """
+
+    def __init__(self, client: StubClient) -> None:
+        self._resource: Type[Deployment] = Deployment
+        self._client = client
+        self._request_builder = RequestBuilder(
+            resource_config=Deployment.__RESOURCE_CONFIG__,
+        )
+        self._namespace: NamespaceTypes = "default"
+
+    def _ensure_required_namespace(self, namespace: Any) -> NamespaceTypes:
+        return "default"
+
+    def _ensure_optional_namespace(self, namespace: Any) -> NamespaceTypes:
+        return "default"
+
+
+def _pod_api(client: StubClient) -> Api[Pod]:
+    return Api(Pod, client=client, namespace="default")
+
+
+@pytest.mark.anyio
+async def test_get_no_override_leaves_request_timeout_as_ellipsis() -> None:
+    client = StubClient(
+        response_content=b'{"apiVersion": "v1", "kind": "Pod", "metadata": {"name": "x"}}'
+    )
+    await _pod_api(client).get("x")
+    assert client.last_request.timeout is Ellipsis
+
+
+@pytest.mark.anyio
+async def test_get_float_override_sets_total() -> None:
+    client = StubClient(
+        response_content=b'{"apiVersion": "v1", "kind": "Pod", "metadata": {"name": "x"}}'
+    )
+    await _pod_api(client).get("x", request_timeout=2.5)
+    assert client.last_request.timeout == Timeout(total=2.5)
+
+
+@pytest.mark.anyio
+async def test_get_none_override_disables_timeout() -> None:
+    client = StubClient(
+        response_content=b'{"apiVersion": "v1", "kind": "Pod", "metadata": {"name": "x"}}'
+    )
+    await _pod_api(client).get("x", request_timeout=None)
+    assert client.last_request.timeout is None
+
+
+@pytest.mark.anyio
+async def test_get_timeout_instance_passthrough() -> None:
+    timeout = Timeout(connect=1, read=2)
+    client = StubClient(
+        response_content=b'{"apiVersion": "v1", "kind": "Pod", "metadata": {"name": "x"}}'
+    )
+    await _pod_api(client).get("x", request_timeout=timeout)
+    assert client.last_request.timeout is timeout
+
+
+@pytest.mark.anyio
+async def test_list_override_flows_through_without_colliding_with_server_timeout() -> (
+    None
+):
+    client = StubClient(
+        response_content=(
+            b'{"apiVersion": "v1", "kind": "PodList", "metadata": {}, "items": []}'
+        )
+    )
+    await _pod_api(client).list(timeout=30, request_timeout=4.0)
+    req = client.last_request
+    assert req.timeout == Timeout(total=4.0)
+    # Server-side Kubernetes timeout remains on the query string
+    assert req.query_params is not None
+    assert req.query_params.get("timeoutSeconds") == "30"
+
+
+@pytest.mark.anyio
+async def test_watch_override_flows_through() -> None:
+    watch_line = json.dumps(
+        {
+            "type": "ADDED",
+            "object": {
+                "apiVersion": "v1",
+                "kind": "Pod",
+                "metadata": {"name": "x"},
+            },
+        }
+    )
+    client = StubClient(stream_lines=[watch_line])
+    api = _pod_api(client)
+    events = [event async for event in api.watch(request_timeout=7.5)]
+    assert len(events) == 1
+    assert client.last_request.timeout == Timeout(total=7.5)
+
+
+@pytest.mark.anyio
+async def test_create_override_flows_through() -> None:
+    client = StubClient(
+        response_content=b'{"apiVersion": "v1", "kind": "Pod", "metadata": {"name": "x"}}'
+    )
+    pod = Pod.model_validate(
+        {"apiVersion": "v1", "kind": "Pod", "metadata": {"name": "x"}}
+    )
+    await _pod_api(client).create(pod, request_timeout=1.0)
+    assert client.last_request.timeout == Timeout(total=1.0)
+
+
+@pytest.mark.anyio
+async def test_delete_override_flows_through() -> None:
+    client = StubClient(
+        response_content=b'{"apiVersion": "v1", "kind": "Pod", "metadata": {"name": "x"}}'
+    )
+    await _pod_api(client).delete("x", request_timeout=2.0)
+    assert client.last_request.timeout == Timeout(total=2.0)
+
+
+@pytest.mark.anyio
+async def test_patch_override_flows_through() -> None:
+    client = StubClient(
+        response_content=b'{"apiVersion": "v1", "kind": "Pod", "metadata": {"name": "x"}}'
+    )
+    patch = MergePatch(Pod.model_validate({"metadata": {"labels": {"a": "b"}}}))
+    await _pod_api(client).patch("x", patch, request_timeout=3.0)
+    assert client.last_request.timeout == Timeout(total=3.0)
+
+
+@pytest.mark.anyio
+async def test_logs_override_flows_through() -> None:
+    client = StubClient(response_content=b"log-line\n")
+    api = _pod_api(client)
+    await api.logs("x", request_timeout=5.0)
+    assert client.last_request.timeout == Timeout(total=5.0)
+
+
+@pytest.mark.anyio
+async def test_stream_logs_override_flows_through() -> None:
+    client = StubClient(stream_lines=["hello"])
+    api = _pod_api(client)
+    lines = [line async for line in api.stream_logs("x", request_timeout=6.0)]
+    assert lines == ["hello"]
+    assert client.last_request.timeout == Timeout(total=6.0)
+
+
+@pytest.mark.anyio
+async def test_list_metadata_override_flows_through() -> None:
+    client = StubClient(
+        response_content=(
+            b'{"apiVersion": "meta.k8s.io/v1", "kind": "PartialObjectMetadataList",'
+            b' "metadata": {}, "items": []}'
+        )
+    )
+    await _pod_api(client).list_metadata(request_timeout=8.0)
+    assert client.last_request.timeout == Timeout(total=8.0)
+
+
+@pytest.mark.anyio
+async def test_get_metadata_override_flows_through() -> None:
+    client = StubClient(
+        response_content=(
+            b'{"apiVersion": "meta.k8s.io/v1", "kind": "PartialObjectMetadata",'
+            b' "metadata": {"name": "x"}}'
+        )
+    )
+    await _pod_api(client).get_metadata("x", request_timeout=9.0)
+    assert client.last_request.timeout == Timeout(total=9.0)
+
+
+@pytest.mark.anyio
+async def test_get_scale_override_flows_through() -> None:
+    client = StubClient(
+        response_content=(
+            b'{"apiVersion": "autoscaling/v1", "kind": "Scale",'
+            b' "metadata": {"name": "x"}, "spec": {"replicas": 1}}'
+        )
+    )
+    await _ScaleOnly(client).get_scale("x", request_timeout=10.0)
+    assert client.last_request.timeout == Timeout(total=10.0)

--- a/test/test_timeout/test_configuration.py
+++ b/test/test_timeout/test_configuration.py
@@ -1,0 +1,36 @@
+from kubex.configuration import ClientConfiguration
+from kubex.core.params import Timeout
+
+
+def _base_config(**kwargs: object) -> ClientConfiguration:
+    return ClientConfiguration(
+        url="https://example.invalid",
+        insecure_skip_tls_verify=True,
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+def test_default_timeout_is_ellipsis() -> None:
+    config = _base_config()
+    assert config.timeout is Ellipsis
+
+
+def test_explicit_none_preserved() -> None:
+    config = _base_config(timeout=None)
+    assert config.timeout is None
+
+
+def test_int_normalized_to_timeout() -> None:
+    config = _base_config(timeout=3)
+    assert config.timeout == Timeout(total=3.0)
+
+
+def test_float_normalized_to_timeout() -> None:
+    config = _base_config(timeout=2.5)
+    assert config.timeout == Timeout(total=2.5)
+
+
+def test_timeout_instance_passthrough() -> None:
+    t = Timeout(connect=1, read=2)
+    config = _base_config(timeout=t)
+    assert config.timeout is t

--- a/test/test_timeout/test_httpx_client.py
+++ b/test/test_timeout/test_httpx_client.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pytest
+
+from kubex.configuration import ClientConfiguration
+from kubex.core.params import Timeout
+
+httpx = pytest.importorskip("httpx")
+
+from kubex.client.httpx import HttpxClient, _to_httpx_timeout  # noqa: E402
+
+
+def _configuration(**kwargs: object) -> ClientConfiguration:
+    return ClientConfiguration(
+        url="https://example.invalid",
+        insecure_skip_tls_verify=True,
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+def test_create_inner_client_without_timeout_uses_httpx_default() -> None:
+    client = HttpxClient(_configuration())
+    # Constructing without a timeout should leave httpx's default in place.
+    assert client._inner_client.timeout == httpx.Timeout(5.0)
+
+
+def test_create_inner_client_with_timeout() -> None:
+    client = HttpxClient(_configuration(timeout=5))
+    assert client._inner_client.timeout == httpx.Timeout(5.0)
+
+
+def test_create_inner_client_with_none_disables_timeout() -> None:
+    client = HttpxClient(_configuration(timeout=None))
+    assert client._inner_client.timeout == httpx.Timeout(None)
+
+
+def test_to_httpx_timeout_translates_granular_fields() -> None:
+    translated = _to_httpx_timeout(Timeout(total=5, connect=1, read=2, write=3, pool=4))
+    assert translated == httpx.Timeout(5.0, connect=1, read=2, write=3, pool=4)
+
+
+def test_to_httpx_timeout_none_means_disabled() -> None:
+    translated = _to_httpx_timeout(None)
+    assert translated == httpx.Timeout(None)

--- a/test/test_timeout/test_params.py
+++ b/test/test_timeout/test_params.py
@@ -1,0 +1,38 @@
+from kubex.core.params import Timeout
+
+
+def test_coerce_none_returns_none() -> None:
+    assert Timeout.coerce(None) is None
+
+
+def test_coerce_int_becomes_total() -> None:
+    result = Timeout.coerce(5)
+    assert result == Timeout(total=5.0)
+
+
+def test_coerce_float_becomes_total() -> None:
+    result = Timeout.coerce(1.5)
+    assert result == Timeout(total=1.5)
+
+
+def test_coerce_timeout_returns_same_instance() -> None:
+    original = Timeout(connect=2)
+    assert Timeout.coerce(original) is original
+
+
+def test_timeout_repr_includes_all_fields() -> None:
+    text = repr(Timeout(total=1, connect=2, read=3, write=4, pool=5))
+    assert "total=1" in text
+    assert "connect=2" in text
+    assert "read=3" in text
+    assert "write=4" in text
+    assert "pool=5" in text
+
+
+def test_timeout_equality_by_fields() -> None:
+    assert Timeout(total=1, connect=2) == Timeout(total=1, connect=2)
+    assert Timeout(total=1) != Timeout(total=2)
+
+
+def test_timeout_not_equal_to_non_timeout() -> None:
+    assert Timeout(total=1) != "Timeout(total=1)"

--- a/test/test_timeout/test_request.py
+++ b/test/test_timeout/test_request.py
@@ -1,0 +1,11 @@
+from kubex.core.request import Request
+
+
+def test_request_timeout_default_is_ellipsis() -> None:
+    request = Request(method="GET", url="/api/v1/namespaces")
+    assert request.timeout is Ellipsis
+
+
+def test_request_timeout_repr_includes_timeout() -> None:
+    request = Request(method="GET", url="/api/v1/namespaces")
+    assert "timeout=" in repr(request)


### PR DESCRIPTION
Introduce a client-agnostic Timeout abstraction so users can configure
httpx/aiohttp timeouts globally via ClientConfiguration and override
them per call with a new request_timeout kwarg on every Api method
(including streaming calls). Ellipsis is used as the sentinel for "not
provided"; None explicitly disables the timeout.

Covered by new unit tests under test/test_timeout/ (no Docker required).